### PR TITLE
use XDG specification instead of global dotfile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc::channel;
 use std::time::Duration;
 
 fn main() {
-    let home = dirs::home_dir().unwrap().join(".dotsy");
+    let home = dirs::data_dir().unwrap().join("dotsy");
     if let Err(e) = fs::create_dir_all(&home) {
         panic!("{} at {:?}", e, home);
     }


### PR DESCRIPTION
Creo que puede ser de importancia seguir las recomendaciones de XDG en vez de contaminar el directorio home de los usuarios con más `.archivos` o `.directorios`. Fuera de eso el comportamiento queda igual.